### PR TITLE
Use 'merge' merge method instead of 'squash'

### DIFF
--- a/chlog/merge_and_label.go
+++ b/chlog/merge_and_label.go
@@ -25,7 +25,7 @@ type changelogCategory struct {
 
 var (
 	mergeCommentRegexp = regexp.MustCompile("@[a-zA-Z-_]+: (merge|:shipit:|:ship:)( \\+([a-zA-Z-_ ]+))?")
-	mergeOptions       = &github.PullRequestOptions{MergeMethod: "squash"}
+	mergeOptions       = &github.PullRequestOptions{MergeMethod: "merge"}
 
 	categories = []changelogCategory{
 		{


### PR DESCRIPTION
The 'merge' method allows us to preserve a better history of the work of
our contributors.