### PR TITLE
Revert "Use 'merge' merge method instead of 'squash'"

### DIFF
--- a/chlog/merge_and_label.go
+++ b/chlog/merge_and_label.go
@@ -25,7 +25,7 @@ type changelogCategory struct {
 
 var (
 	mergeCommentRegexp = regexp.MustCompile("@[a-zA-Z-_]+: (merge|:shipit:|:ship:)( \\+([a-zA-Z-_ ]+))?")
-	mergeOptions       = &github.PullRequestOptions{MergeMethod: "merge"}
+	mergeOptions       = &github.PullRequestOptions{MergeMethod: "squash"}
 
 	categories = []changelogCategory{
 		{


### PR DESCRIPTION
Reverts jekyll/jekyllbot#1

Because it got merged unintentionally when Jekyllbot *misunderstood* my https://github.com/jekyll/jekyllbot/pull/1#issuecomment-538045858 :roll_eyes: