### PR TITLE
Don't monitor issues at 'jekyll/jekyll-admin'

### DIFF
--- a/cmd/mark-and-sweep-stale-issues/mark_and_sweep_stale_issues.go
+++ b/cmd/mark-and-sweep-stale-issues/mark_and_sweep_stale_issues.go
@@ -36,7 +36,6 @@ var (
 	// All the repos to apply apply these to.
 	defaultRepos = []repo{
 		{"jekyll", "jekyll"},
-		{"jekyll", "jekyll-admin"},
 		{"jekyll", "jekyll-import"},
 		{"jekyll", "github-metadata"},
 		{"jekyll", "jekyll-redirect-from"},


### PR DESCRIPTION
Issues need not be marked `stale` and closed automatically.