### PR TITLE
Support pull request review merges

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -20,12 +20,12 @@ type authenticator struct {
 	context *ctx.Context
 }
 
-func CommenterHasPushAccess(context *ctx.Context, event github.IssueCommentEvent) bool {
+func CommenterHasPushAccess(context *ctx.Context, owner, repo, commenterLogin string) bool {
 	auth := authenticator{context: context}
-	orgTeams := auth.teamsForOrg(*event.Repo.Owner.Login)
+	orgTeams := auth.teamsForOrg(owner)
 	for _, team := range orgTeams {
-		if auth.isTeamMember(*team.ID, *event.Comment.User.Login) &&
-			auth.teamHasPushAccess(*team.ID, *event.Repo.Owner.Login, *event.Repo.Name) {
+		if auth.isTeamMember(*team.ID, commenterLogin) &&
+			auth.teamHasPushAccess(*team.ID, owner, repo) {
 			return true
 		}
 	}

--- a/chlog/merge_and_label.go
+++ b/chlog/merge_and_label.go
@@ -121,6 +121,8 @@ func parseIssueCommentEvent(context *ctx.Context, event *github.IssueCommentEven
 	}
 	fmt.Printf("changeSectionLabel = '%s'\n", req.ChangeSectionLabel)
 
+	req.CommenterLogin = *event.Comment.User.Login
+
 	return *req, nil
 }
 
@@ -128,7 +130,7 @@ func parsePullRequestReviewEvent(context *ctx.Context, event *github.PullRequest
 	req := &mergeAndLabelRequest{}
 
 	if event.GetAction() != "submitted" {
-		return *req, context.NewError("MergeAndLabel: review is %q, not submitted", event.GetAction())
+		return *req, context.NewError("MergeAndLabel: review action is %q, not submitted", event.GetAction())
 	}
 
 	req.Owner, req.Repo, req.PullNumber = *event.Repo.Owner.Login, *event.Repo.Name, *event.PullRequest.Number

--- a/chlog/merge_and_label.go
+++ b/chlog/merge_and_label.go
@@ -17,6 +17,8 @@ import (
 	"github.com/parkr/changelog"
 )
 
+const changeSectionLabelNone = "none"
+
 // changelogCategory is a changelog category, like "Site Enhancements" and such.
 type changelogCategory struct {
 	Prefix, Slug, Section string
@@ -76,12 +78,6 @@ var (
 			Section: "Site Enhancements",
 			Labels:  []string{"documentation"},
 		},
-		{
-			Prefix:  "other",
-			Slug:    "other",
-			Section: "Other",
-			Labels:  []string{"internal"},
-		},
 	}
 )
 
@@ -117,7 +113,7 @@ func parseIssueCommentEvent(context *ctx.Context, event *github.IssueCommentEven
 	if labelFromComment != "" {
 		req.ChangeSectionLabel = sectionForLabel(labelFromComment)
 	} else {
-		req.ChangeSectionLabel = "other"
+		req.ChangeSectionLabel = changeSectionLabelNone
 	}
 	fmt.Printf("changeSectionLabel = '%s'\n", req.ChangeSectionLabel)
 
@@ -148,7 +144,7 @@ func parsePullRequestReviewEvent(context *ctx.Context, event *github.PullRequest
 	if labelFromComment != "" {
 		req.ChangeSectionLabel = sectionForLabel(labelFromComment)
 	} else {
-		req.ChangeSectionLabel = "other"
+		req.ChangeSectionLabel = changeSectionLabelNone
 	}
 	fmt.Printf("changeSectionLabel = '%s'\n", req.ChangeSectionLabel)
 
@@ -375,7 +371,7 @@ func addMergeReference(historyFileContents, changeSectionLabel, prTitle string, 
 	}
 
 	// Put either directly in the version history or in a subsection.
-	if changeSectionLabel == "none" {
+	if changeSectionLabel == changeSectionLabelNone {
 		changes.AddLineToVersion("HEAD", changeLine)
 	} else {
 		changes.AddLineToSubsection("HEAD", changeSectionLabel, changeLine)

--- a/chlog/merge_and_label_test.go
+++ b/chlog/merge_and_label_test.go
@@ -19,7 +19,7 @@ func TestParseMergeAndLabelRequest(t *testing.T) {
 
 	payload = &github.PullRequestReviewEvent{}
 	_, err = parseMergeAndLabelRequest(context, payload)
-	assert.EqualError(t, err, "MergeAndLabel: pull_request_review event not yet supported")
+	assert.EqualError(t, err, "MergeAndLabel: review action is \"\", not submitted")
 
 	payload = &github.PullRequestReviewCommentEvent{}
 	_, err = parseMergeAndLabelRequest(context, payload)
@@ -93,6 +93,7 @@ func TestParseIssueCommentEvent_NoChangelogLabel(t *testing.T) {
 			Name:  github.String("foo"),
 		},
 		Comment: &github.IssueComment{
+			User: &github.User{Login: github.String("monalisa")},
 			Body: github.String("@jekyllbot: merge"),
 		},
 	}
@@ -102,6 +103,7 @@ func TestParseIssueCommentEvent_NoChangelogLabel(t *testing.T) {
 	assert.Equal(t, "owner-login", req.Owner)
 	assert.Equal(t, "foo", req.Repo)
 	assert.Equal(t, 456, req.PullNumber)
+	assert.Equal(t, "monalisa", req.CommenterLogin)
 	assert.Equal(t, "other", req.ChangeSectionLabel)
 }
 
@@ -117,6 +119,7 @@ func TestParseIssueCommentEvent_Works(t *testing.T) {
 			Name:  github.String("foo"),
 		},
 		Comment: &github.IssueComment{
+			User: &github.User{Login: github.String("monalisa")},
 			Body: github.String("@jekyllbot: merge +fix"),
 		},
 	}

--- a/chlog/merge_and_label_test.go
+++ b/chlog/merge_and_label_test.go
@@ -26,8 +26,32 @@ func TestParseMergeAndLabelRequest(t *testing.T) {
 	assert.EqualError(t, err, "MergeAndLabel: not an issue_comment or pull_request_review event")
 }
 
-func TestParsePullRequestReviewEvent(t *testing.T) {
-	t.Fatal("TODO")
+func TestParsePullRequestReviewEvent_Works(t *testing.T) {
+	context := ctx.NewTestContext()
+	event := &github.PullRequestReviewEvent{
+		Action: github.String("submitted"),
+		PullRequest: &github.PullRequest{
+			Number: github.Int(456),
+		},
+		Review: &github.PullRequestReview{
+			User: &github.User{
+				Login: github.String("monalisa"),
+			},
+			Body: github.String("@jekyllbot: merge +fix"),
+		},
+		Repo: &github.Repository{
+			Owner: &github.User{Login: github.String("owner-login")},
+			Name:  github.String("foo"),
+		},
+	}
+	req, err := parsePullRequestReviewEvent(context, event)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "owner-login", req.Owner)
+	assert.Equal(t, "foo", req.Repo)
+	assert.Equal(t, 456, req.PullNumber)
+	assert.Equal(t, "monalisa", req.CommenterLogin)
+	assert.Equal(t, "Bug Fixes", req.ChangeSectionLabel)
 }
 func TestParseIssueCommentEvent_NotPullRequest(t *testing.T) {
 	context := ctx.NewTestContext()

--- a/ctx/context.go
+++ b/ctx/context.go
@@ -55,3 +55,7 @@ func WithRepo(owner, repo string) *Context {
 	context.SetRepo(owner, repo)
 	return context
 }
+
+func NewTestContext() *Context {
+	return &Context{}
+}

--- a/lgtm/lgtm.go
+++ b/lgtm/lgtm.go
@@ -95,7 +95,7 @@ func (h *Handler) IssueCommentHandler(context *ctx.Context, payload interface{})
 	}
 
 	// Does the user have merge/label abilities?
-	if !auth.CommenterHasPushAccess(context, *comment) {
+	if !auth.CommenterHasPushAccess(context, *comment.Repo.Owner.Login, *comment.Repo.Name, lgtmer) {
 		return context.NewError(
 			"%s isn't authenticated to merge anything on %s/%s",
 			*comment.Comment.User.Login, ref.Repo.Owner, ref.Repo.Name)


### PR DESCRIPTION
`@mattr-` tried merging a PR from the PR review comment and it failed since Jekyllbot needs to be taught how to merge these (https://github.com/jekyll/jekyll/pull/9049#pullrequestreview-966709014).

I abstracted the event type from the merge request, so that it's a separate struct of data. Any event type can thus be parsed into this merge request in the future.

Tests were lacking for this functionality, so I also added some of those.