### PR TITLE
Fix auth by including the organization in the Team struct

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -104,6 +104,14 @@ func (auth authenticator) teamsForOrg(org string) []*github.Team {
 			log.Printf("ERROR performing ListTeams(\"%s\"): %v", org, err)
 			return nil
 		}
+		orgData, _, err := auth.context.GitHub.Organizations.Get(auth.context.Context(), org)
+		if err != nil {
+			log.Printf("ERROR performing GetOrg(\"%s\"): %v", org, err)
+			return nil
+		}
+		for _, team := range teamz {
+			team.Organization = orgData
+		}
 		teamsCache[org] = teamz
 	}
 	return teamsCache[org]


### PR DESCRIPTION
```text
2022-06-21T02:17:12.629749+00:00 app[web.1]: panic: runtime error: invalid memory address or nil pointer dereference
2022-06-21T02:17:12.629759+00:00 app[web.1]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x7c674b]
2022-06-21T02:17:12.629763+00:00 app[web.1]: 
2022-06-21T02:17:12.629764+00:00 app[web.1]: goroutine 1745 [running]:
2022-06-21T02:17:12.629921+00:00 app[web.1]: github.com/jekyll/jekyllbot/auth.CommenterHasPushAccess(0x90d90f, {0xc000a59220, 0x6}, {0xc000a59206, 0x6}, {0xc000a5918a, 0x5})
2022-06-21T02:17:12.629969+00:00 app[web.1]: /tmp/build_eba97da9/auth/auth.go:35 +0x8b
2022-06-21T02:17:12.630060+00:00 app[web.1]: github.com/jekyll/jekyllbot/chlog.MergeAndLabel(0xc00010e000, {0x8b9f40, 0xc0000da340})
2022-06-21T02:17:12.630129+00:00 app[web.1]: /tmp/build_eba97da9/chlog/merge_and_label.go:180 +0x2cb
2022-06-21T02:17:12.630141+00:00 app[web.1]: created by github.com/jekyll/jekyllbot/hooks.(*GlobalHandler).FireHandlers
2022-06-21T02:17:12.630197+00:00 app[web.1]: /tmp/build_eba97da9/hooks/global_handler.go:102 +0x155
```