### PR TITLE
build: bump go to 1.25

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,6 @@ jobs:
     - name: Setup Go environment
       uses: actions/setup-go@v6
       with:
-        go-version: 1.23
+        go-version: 1.25
     - name: Run
       run: make test


### PR DESCRIPTION
go 1.26 is out as well, but i'm sticking with 1.25 for now
